### PR TITLE
Add support for stack

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -4,7 +4,6 @@ module Main (main) where
 
 import Data.List ( nub )
 import Data.Version ( showVersion )
-import Control.Applicative
 import Distribution.Package ( PackageName(PackageName), PackageId, InstalledPackageId, packageVersion, packageName )
 import Distribution.PackageDescription ( PackageDescription(), TestSuite(..) )
 import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )

--- a/Setup.hs
+++ b/Setup.hs
@@ -1,9 +1,13 @@
 #!/usr/bin/env runhaskell
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -Wall #-}
 module Main (main) where
 
 import Data.List ( nub )
 import Data.Version ( showVersion )
+#if __GLASGOW_HASKELL__ < 710
+import Control.Applicative
+#endif
 import Distribution.Package ( PackageName(PackageName), PackageId, InstalledPackageId, packageVersion, packageName )
 import Distribution.PackageDescription ( PackageDescription(), TestSuite(..) )
 import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )

--- a/geojson.cabal
+++ b/geojson.cabal
@@ -37,8 +37,8 @@ library
     default-language:   Haskell2010
 
     build-depends:      base < 5 &&     >= 4
-                    ,   aeson           == 0.9.*
-                    ,   lens            == 4.11.*
+                    ,   aeson           >= 0.8       && < 1.0
+                    ,   lens            >= 4.11      && < 4.13
                     ,   semigroups      == 0.16.*
                     ,   text            == 1.2.*
                     ,   transformers    >= 0.3       && < 0.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+flags: {}
+packages:
+- '.'
+extra-deps:
+  - validation-0.5.1
+resolver: lts-3.2


### PR DESCRIPTION
See #11

Changes:
* Relax `aeson` and `lens` version boundaries
* Conditional compilation for reduntant import in `Setup.hs` (in 7.10 Control.Applicative is a part of Prelude)
* Stack file with single extra dependency for `validation` package